### PR TITLE
PART 4 - Exception when exiting from App with no editors

### DIFF
--- a/bundles/org.eclipse.swt.gtk.linux.x86_64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt.gtk.linux.x86_64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt; bundle-version="[3.0.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.x86_64; singleton:=true
-Bundle-Version: 3.110.0.lgc20200622-1200
+Bundle-Version: 3.110.0.lgc20200707-1200
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/bundles/org.eclipse.swt.gtk.linux.x86_64/pom.xml
+++ b/bundles/org.eclipse.swt.gtk.linux.x86_64/pom.xml
@@ -21,7 +21,7 @@
   </parent>
   <groupId>org.eclipse.swt</groupId>
   <artifactId>org.eclipse.swt.gtk.linux.x86_64</artifactId>
-  <version>3.110.0.lgc20200622-1200</version>
+  <version>3.110.0.lgc20200707-1200</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/bundles/org.eclipse.swt.win32.win32.x86_64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt.win32.win32.x86_64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt; bundle-version="[3.0.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.win32.win32.x86_64; singleton:=true
-Bundle-Version: 3.110.0.lgc20200622-1200
+Bundle-Version: 3.110.0.lgc20200707-1200
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/bundles/org.eclipse.swt.win32.win32.x86_64/pom.xml
+++ b/bundles/org.eclipse.swt.win32.win32.x86_64/pom.xml
@@ -21,7 +21,7 @@
   </parent>
   <groupId>org.eclipse.swt</groupId>
   <artifactId>org.eclipse.swt.win32.win32.x86_64</artifactId>
-  <version>3.110.0.lgc20200622-1200</version>
+  <version>3.110.0.lgc20200707-1200</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>


### PR DESCRIPTION
Problem: Exception when exiting from App with no editors. Parent get disposed due to event queue clearing in BrowserPanel.handleEvent. while(Display.getDefault().readAndDispatch()).

Solution: Add check for widget is disposed.

Part 1 - https://github.com/Halliburton-Landmark/eclipse.platform.swt/pull/15
Part 2 - https://github.com/Halliburton-Landmark/eclipse.platform.ui/pull/31