### PR TITLE
bugfix_702914 Linux PART 2 - Exception when exiting from App with no editors

### DIFF
--- a/bundles/org.eclipse.swt.gtk.linux.x86_64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt.gtk.linux.x86_64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt; bundle-version="[3.0.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.x86_64; singleton:=true
-Bundle-Version: 3.110.0.lgc20201507-1200
+Bundle-Version: 3.110.0.lgc20200715-1200
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/bundles/org.eclipse.swt.gtk.linux.x86_64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt.gtk.linux.x86_64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt; bundle-version="[3.0.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.gtk.linux.x86_64; singleton:=true
-Bundle-Version: 3.110.0.lgc20200707-1200
+Bundle-Version: 3.110.0.lgc20201507-1200
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/bundles/org.eclipse.swt.gtk.linux.x86_64/pom.xml
+++ b/bundles/org.eclipse.swt.gtk.linux.x86_64/pom.xml
@@ -21,7 +21,7 @@
   </parent>
   <groupId>org.eclipse.swt</groupId>
   <artifactId>org.eclipse.swt.gtk.linux.x86_64</artifactId>
-  <version>3.110.0.lgc20201507-1200</version>
+  <version>3.110.0.lgc20200715-1200</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/bundles/org.eclipse.swt.gtk.linux.x86_64/pom.xml
+++ b/bundles/org.eclipse.swt.gtk.linux.x86_64/pom.xml
@@ -21,7 +21,7 @@
   </parent>
   <groupId>org.eclipse.swt</groupId>
   <artifactId>org.eclipse.swt.gtk.linux.x86_64</artifactId>
-  <version>3.110.0.lgc20200707-1200</version>
+  <version>3.110.0.lgc20201507-1200</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/bundles/org.eclipse.swt.win32.win32.x86_64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt.win32.win32.x86_64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt; bundle-version="[3.0.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.win32.win32.x86_64; singleton:=true
-Bundle-Version: 3.110.0.lgc20201507-1200
+Bundle-Version: 3.110.0.lgc20200715-1200
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/bundles/org.eclipse.swt.win32.win32.x86_64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.swt.win32.win32.x86_64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Fragment-Host: org.eclipse.swt; bundle-version="[3.0.0,4.0.0)"
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.swt.win32.win32.x86_64; singleton:=true
-Bundle-Version: 3.110.0.lgc20200707-1200
+Bundle-Version: 3.110.0.lgc20201507-1200
 Bundle-ManifestVersion: 2
 Bundle-Localization: fragment
 Export-Package: 

--- a/bundles/org.eclipse.swt.win32.win32.x86_64/pom.xml
+++ b/bundles/org.eclipse.swt.win32.win32.x86_64/pom.xml
@@ -21,7 +21,7 @@
   </parent>
   <groupId>org.eclipse.swt</groupId>
   <artifactId>org.eclipse.swt.win32.win32.x86_64</artifactId>
-  <version>3.110.0.lgc20200707-1200</version>
+  <version>3.110.0.lgc20201507-1200</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/bundles/org.eclipse.swt.win32.win32.x86_64/pom.xml
+++ b/bundles/org.eclipse.swt.win32.win32.x86_64/pom.xml
@@ -21,7 +21,7 @@
   </parent>
   <groupId>org.eclipse.swt</groupId>
   <artifactId>org.eclipse.swt.win32.win32.x86_64</artifactId>
-  <version>3.110.0.lgc20201507-1200</version>
+  <version>3.110.0.lgc20200715-1200</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>


### PR DESCRIPTION
**Problem:** Exception on Linux when exiting from App with no editors. Parent get disposed due to event queue clearing in BrowserPanel.handleEvent. while(Display.getDefault().readAndDispatch()).

org.eclipse.swt.SWTException: Widget is disposed
at org.eclipse.swt.SWT.error(SWT.java:4699)
at org.eclipse.swt.SWT.error(SWT.java:4614)
at org.eclipse.swt.SWT.error(SWT.java:4585)
at org.eclipse.swt.widgets.Widget.error(Widget.java:530)
at org.eclipse.swt.widgets.Widget.getDisplay(Widget.java:616)
at org.eclipse.swt.browser.WebKit.onDispose(WebKit.java:2596)
at org.eclipse.swt.browser.WebKit.lambda$4(WebKit.java:1312)
at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:89)
at org.eclipse.swt.widgets.Display.sendEvent(Display.java:5783)
at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1411)
at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1437)
at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1416)
at org.eclipse.swt.widgets.Widget.release(Widget.java:1228)
at org.eclipse.swt.widgets.Control.release(Control.java:4570)
at org.eclipse.swt.widgets.Composite.releaseChildren(Composite.java:1489)
at org.eclipse.swt.widgets.Widget.release(Widget.java:1231)
at org.eclipse.swt.widgets.Control.release(Control.java:4570)
at org.eclipse.swt.widgets.Composite.releaseChildren(Composite.java:1489)
at org.eclipse.swt.widgets.Widget.release(Widget.java:1231)
at org.eclipse.swt.widgets.Control.release(Control.java:4570)
at org.eclipse.swt.widgets.Composite.releaseChildren(Composite.java:1489)
at org.eclipse.swt.widgets.Widget.release(Widget.java:1231)
at org.eclipse.swt.widgets.Control.release(Control.java:4570)
at org.eclipse.swt.widgets.Composite.releaseChildren(Composite.java:1489)
at org.eclipse.swt.widgets.Widget.release(Widget.java:1231)
at org.eclipse.swt.widgets.Control.release(Control.java:4570)
at org.eclipse.swt.widgets.Composite.releaseChildren(Composite.java:1489)
at org.eclipse.swt.widgets.Widget.release(Widget.java:1231)
at org.eclipse.swt.widgets.Control.release(Control.java:4570)
at org.eclipse.swt.widgets.Widget.dispose(Widget.java:526)
at org.eclipse.e4.ui.workbench.renderers.swt.SWTPartRenderer.disposeWidget(SWTPartRenderer.java:175)
at org.eclipse.e4.ui.workbench.renderers.swt.ContributedPartRenderer.disposeWidget(ContributedPartRenderer.java:273)
at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.safeRemoveGui(PartRenderingEngine.java:958)
at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.access$1(PartRenderingEngine.java:886)
at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$4.run(PartRenderingEngine.java:881)
at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:45)

**Solution:** Add check for widget is disposed.

Part 1 - https://github.com/Halliburton-Landmark/eclipse.platform.swt/pull/17